### PR TITLE
SP21+/SP22 compatibility + 9 broken-tool fixes

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -188,7 +188,35 @@ export class CodesysLauncher implements ScriptExecutor {
 
   /** Graceful shutdown */
   async shutdown(): Promise<void> {
-    if (this.state === 'stopped' || this.state === 'stopping') return;
+    // Orphan-killing fallback: if the launcher itself has no tracked PID
+    // (state stopped/error after a fresh MCP server start) but a CODESYS.exe
+    // is alive on the box from a previous session, the previous early-return
+    // would say "shutdown_codesys success" and do nothing. This left the
+    // launcher's refuse-on-duplicate guard permanently blocking new spawns.
+    // Now we taskkill any orphans we can find before the early-return so the
+    // tool actually does something useful in this state.
+    if (this.state === 'stopped' || this.state === 'stopping') {
+      if (this.pid === null) {
+        const orphans = findRunningCodesysPids();
+        if (orphans.length > 0) {
+          launcherLog.info(`shutdown_codesys: launcher has no tracked PID but found ${orphans.length} orphan CODESYS.exe (PIDs: ${orphans.join(', ')}). Force-killing.`);
+          for (const pid of orphans) {
+            try {
+              execSync(`taskkill /PID ${pid}`, { timeout: 5000, stdio: 'ignore' });
+            } catch { /* ignore graceful failures, force-kill below */ }
+          }
+          // Give them a moment to close gracefully
+          await this.sleep(2_000);
+          const stillAlive = findRunningCodesysPids();
+          for (const pid of stillAlive) {
+            try {
+              execSync(`taskkill /F /PID ${pid}`, { timeout: 5000, stdio: 'ignore' });
+            } catch { /* nothing else to try */ }
+          }
+        }
+      }
+      return;
+    }
 
     this.setState('stopping');
     this.stopHealthMonitor();

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { spawn, ChildProcess } from 'child_process';
+import { spawn, execSync, ChildProcess } from 'child_process';
 import { v4 as uuidv4 } from 'uuid';
 import { LauncherConfig, LauncherStatus, CodesysState, IpcResult, ScriptExecutor } from './types';
 import { IpcClient, DEFAULT_IPC_CONFIG } from './ipc';
@@ -14,6 +14,40 @@ import { ScriptManager } from './script-manager';
 import { launcherLog } from './logger';
 
 const SESSION_DIR_PREFIX = 'codesys-mcp-persistent';
+
+/**
+ * Returns the PIDs of every CODESYS.exe currently running on this Windows
+ * machine -- whether spawned by this launcher, by a previous MCP session that
+ * crashed without cleanup, or by the user opening CODESYS interactively.
+ *
+ * Used as a pre-launch guard so the launcher never spawns a second CODESYS
+ * alongside an existing one. Two CODESYS instances against the same project
+ * file race on the lock and the loser pops a "project is currently in use"
+ * modal that freezes the IDE thread, breaking every subsequent script call
+ * with 60s timeouts. The cheapest fix is to refuse the duplicate spawn.
+ *
+ * Returns an empty list on non-Windows or if tasklist fails (we treat that
+ * as "can't tell" rather than blocking; the user always retains the option
+ * to close manually).
+ */
+function findRunningCodesysPids(): number[] {
+  if (process.platform !== 'win32') return [];
+  try {
+    const out = execSync(
+      'tasklist /FI "IMAGENAME eq CODESYS.exe" /FO CSV /NH',
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }
+    );
+    const pids: number[] = [];
+    for (const line of out.split(/\r?\n/)) {
+      // CSV with quotes: "CODESYS.exe","12345","Console","1","456,789 K"
+      const m = line.match(/^"CODESYS\.exe","(\d+)"/);
+      if (m) pids.push(Number(m[1]));
+    }
+    return pids;
+  } catch {
+    return [];
+  }
+}
 const READY_TIMEOUT_MS = 60_000;
 const READY_POLL_MS = 500;
 const SHUTDOWN_WAIT_MS = 5_000;
@@ -49,6 +83,29 @@ export class CodesysLauncher implements ScriptExecutor {
       this.setState('error');
       this.lastError = err;
       throw new Error(err);
+    }
+
+    // Refuse to spawn alongside an existing CODESYS.exe. Two instances against
+    // the same project file race on the lock and the loser pops a modal that
+    // freezes script execution. This catches:
+    //   - orphans from a prior MCP session that crashed (exit code 0) without
+    //     taking the IDE down with it
+    //   - the user's own interactive CODESYS instance
+    //   - a CODESYS still mid-shutdown after a previous shutdown_codesys call
+    const existingPids = findRunningCodesysPids();
+    if (existingPids.length > 0) {
+      const msg =
+        `Refusing to launch: ${existingPids.length} CODESYS.exe process(es) ` +
+        `already running (PID(s): ${existingPids.join(', ')}). The MCP launcher ` +
+        `cannot share IPC with an instance it did not spawn, and a second ` +
+        `CODESYS racing on the same project triggers a "project is currently ` +
+        `in use" modal that blocks all script execution. Close the existing ` +
+        `CODESYS window(s) first, or call shutdown_codesys if this server owns ` +
+        `the running instance, then retry.`;
+      launcherLog.warn(msg);
+      this.lastError = msg;
+      this.setState('error');
+      throw new Error(msg);
     }
 
     this.setState('launching');

--- a/src/scripts/add_library.py
+++ b/src/scripts/add_library.py
@@ -1,89 +1,298 @@
 import sys, scriptengine as script_engine, os, traceback
 
+# RTFM (helpme-codesys.com "ScriptLibManObject" + local SP22 stub
+# Stubs/scriptengine/ScriptLibManObject.pyi):
+#
+# - The IDE-level LibManager is injected into the scriptengine scope as the
+#   global name `library_manager` and exposes find_library(display_name) ->
+#   (ManagedLib, LibRepository) | None for resolving a name against the
+#   installed library repositories.
+# - The project-level ScriptLibManObject (`lm` below) has TWO add_library
+#   overloads:
+#       add_library(name: str)       -- ALWAYS adds a placeholder reference
+#                                       (resolution is deferred to load time
+#                                       and silently fails if the placeholder
+#                                       is not registered, bricking the
+#                                       project on the next open).
+#       add_library(library: ManagedLib)  -- adds a MANAGED reference to a
+#                                            specific installed version
+#                                            (since 3.5.5.0).
+# - lm.references gives back ScriptLibraryReference items. Placeholder refs
+#   have .is_placeholder == True, .effective_resolution (a string), and
+#   .name == "#<name>". Managed refs have .name == "<Name>, <Version> (<Company>)".
+# - lm.remove_library(name) removes a reference by name, accepting either
+#   the bare name or the formatted "Name, Version (Company)" string.
+#
+# Bug being fixed: the prior version of this script called
+# lm.add_library(LIBRARY_NAME) with a string. That is the placeholder
+# overload and silently produced an unresolvable placeholder if the name
+# was not also registered as a placeholder in the IDE. The next open then
+# threw "The placeholder library 'X' could not be resolved." and
+# script_engine.projects.primary returned None, bricking the project.
+#
+# Fix:
+#   1. Pre-resolve LIBRARY_NAME via library_manager.find_library() and
+#      prefer the ManagedLib overload of add_library() so we get a managed
+#      reference, not a placeholder.
+#   2. Whatever overload was used, walk lm.references after the add and
+#      verify the new reference resolved (managed -> just exists; placeholder
+#      -> non-empty effective_resolution). If it didn't, call
+#      lm.remove_library(LIBRARY_NAME) and refuse to save -- this prevents
+#      bricking the next open.
+
 LIBRARY_NAME = "{LIBRARY_NAME}"
+
+
+def _resolve_in_repo(name):
+    """Try the IDE-level library_manager.find_library(name) and return the
+    ManagedLib if found, else None. Defensive against older SPs that may
+    not expose find_library or the global injection."""
+    try:
+        lm_global = library_manager  # noqa: F821 -- injected by scriptengine
+    except NameError:
+        print("DEBUG: global 'library_manager' not in scope; skipping pre-resolve.")
+        return None
+    if not hasattr(lm_global, 'find_library'):
+        print("DEBUG: library_manager.find_library not available; skipping pre-resolve.")
+        return None
+    try:
+        result = lm_global.find_library(name)
+    except Exception as e:
+        print("DEBUG: library_manager.find_library('%s') raised: %s" % (name, e))
+        return None
+    if result is None:
+        return None
+    # Stub says: returns tuple(ManagedLib, LibRepository) or None.
+    try:
+        managed_lib = result[0]
+        return managed_lib
+    except Exception:
+        # Some SPs may return the ManagedLib directly.
+        return result
+
+
+def _ref_name_matches(ref_name, target):
+    """A managed ref shows up as 'Name, Version (Company)'; a placeholder
+    shows up as '#Name'. Match on the bare target name in either form."""
+    if ref_name is None:
+        return False
+    if ref_name == target:
+        return True
+    if ref_name == ('#' + target):
+        return True
+    # Managed: leading 'Name, ...'
+    if ref_name.startswith(target + ','):
+        return True
+    return False
+
+
+def _find_added_reference(lm, target):
+    """Walk lm.references and return the entry whose name matches target,
+    or None. Used after add to verify resolution."""
+    try:
+        refs = lm.references
+    except Exception as e:
+        print("DEBUG: lm.references unavailable: %s" % e)
+        return None
+    if refs is None:
+        return None
+    for r in refs:
+        try:
+            rn = getattr(r, 'name', None)
+        except Exception:
+            rn = None
+        if _ref_name_matches(rn, target):
+            return r
+    return None
+
+
+def _is_resolved(ref):
+    """A managed reference (is_managed=True or is_placeholder=False) is
+    always resolved. A placeholder is resolved iff its effective_resolution
+    is a non-empty string."""
+    try:
+        is_ph = bool(getattr(ref, 'is_placeholder', False))
+    except Exception:
+        is_ph = False
+    if not is_ph:
+        return True
+    try:
+        eff = getattr(ref, 'effective_resolution', None)
+    except Exception:
+        eff = None
+    if eff is None:
+        return False
+    s = str(eff).strip()
+    return len(s) > 0
+
+
+def _try_remove(lm, name):
+    """Best-effort removal. SP22 stub documents lm.remove_library(name).
+    Some older SPs may not expose it; in that case we surface the
+    constraint to the caller via the error message."""
+    if not hasattr(lm, 'remove_library'):
+        return False, "lm.remove_library not available on this SP"
+    try:
+        lm.remove_library(name)
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
 
 try:
     print("DEBUG: add_library script: Library='%s', Project='%s'" % (LIBRARY_NAME, PROJECT_FILE_PATH))
     primary_project = ensure_project_open(PROJECT_FILE_PATH)
-    if not LIBRARY_NAME: raise ValueError("Library name empty.")
+    if not LIBRARY_NAME:
+        raise ValueError("Library name empty.")
 
     project_name = os.path.basename(PROJECT_FILE_PATH)
-    lib_manager = None
 
-    # Find Library Manager object
+    # Find the project's Library Manager via the documented container API
+    # (has_library_manager / get_library_manager) -- the same approach
+    # list_project_libraries.py uses. The legacy name-search fallback is
+    # kept below for SPs that don't expose the marker interface.
+    lib_manager = None
     try:
-        found_list = primary_project.find("Library Manager", True)
-        if found_list:
-            lib_manager = found_list[0]
-            print("DEBUG: Found Library Manager via find('Library Manager')")
+        if hasattr(primary_project, 'has_library_manager') and primary_project.has_library_manager:
+            lib_manager = primary_project.get_library_manager()
+            print("DEBUG: Found Library Manager via project.get_library_manager()")
     except Exception as e:
-        print("DEBUG: find('Library Manager') failed: %s" % e)
+        print("DEBUG: project.get_library_manager() failed: %s" % e)
 
     if not lib_manager:
+        # Walk first-level children for a container that has a libman
+        # (typically the Application object).
         try:
-            all_children = primary_project.get_children(True)
-            for child in all_children:
-                child_name = getattr(child, 'get_name', lambda: '')()
-                if 'library' in child_name.lower() and 'manager' in child_name.lower():
-                    lib_manager = child
-                    print("DEBUG: Found Library Manager by name search: %s" % child_name)
-                    break
+            for child in primary_project.get_children(False):
+                try:
+                    if getattr(child, 'has_library_manager', False):
+                        lib_manager = child.get_library_manager()
+                        if lib_manager is not None:
+                            print("DEBUG: Found Library Manager under '%s'" % child.get_name())
+                            break
+                except Exception:
+                    pass
         except Exception as e:
-            print("DEBUG: Children search for Library Manager failed: %s" % e)
+            print("DEBUG: walking children for libman failed: %s" % e)
+
+    if not lib_manager:
+        # Last-resort name-search fallback (preserved from prior version).
+        try:
+            found_list = primary_project.find("Library Manager", True)
+            if found_list:
+                lib_manager = found_list[0]
+                print("DEBUG: Found Library Manager via find('Library Manager') fallback")
+        except Exception as e:
+            print("DEBUG: find('Library Manager') failed: %s" % e)
 
     if not lib_manager:
         raise RuntimeError("Library Manager not found in project '%s'." % project_name)
 
     print("DEBUG: Library Manager found: %s" % getattr(lib_manager, 'get_name', lambda: '?')())
 
-    # Try to add the library using various API patterns
+    # Step 1: pre-resolve the library name against the installed repository.
+    # If found, we will pass the ManagedLib to add_library() to get a
+    # MANAGED reference instead of a placeholder reference.
+    resolved_lib = _resolve_in_repo(LIBRARY_NAME)
+    if resolved_lib is not None:
+        try:
+            disp = getattr(resolved_lib, 'displayname', None) or LIBRARY_NAME
+        except Exception:
+            disp = LIBRARY_NAME
+        print("DEBUG: Pre-resolved '%s' to installed library '%s'." % (LIBRARY_NAME, disp))
+    else:
+        print("DEBUG: Pre-resolve via library_manager.find_library returned no hit for '%s'." % LIBRARY_NAME)
+
+    # Step 2: add the reference, preferring the managed overload.
     added = False
+    add_attempt_errors = []
 
-    # Pattern 1: lib_manager.add_library(name)
-    if hasattr(lib_manager, 'add_library'):
+    if resolved_lib is not None and hasattr(lib_manager, 'add_library'):
         try:
-            result = lib_manager.add_library(LIBRARY_NAME)
+            lib_manager.add_library(resolved_lib)
             added = True
-            print("DEBUG: add_library succeeded: %s" % result)
+            print("DEBUG: add_library(ManagedLib) succeeded.")
         except Exception as e:
-            print("DEBUG: add_library failed: %s" % e)
+            add_attempt_errors.append("add_library(ManagedLib): %s" % e)
+            print("DEBUG: add_library(ManagedLib) failed: %s" % e)
 
-    # Pattern 2: lib_manager.insert_library(name)
-    if not added and hasattr(lib_manager, 'insert_library'):
+    if not added and hasattr(lib_manager, 'add_library'):
         try:
-            result = lib_manager.insert_library(LIBRARY_NAME)
+            lib_manager.add_library(LIBRARY_NAME)
             added = True
-            print("DEBUG: insert_library succeeded: %s" % result)
+            print("DEBUG: add_library(name) succeeded (placeholder overload).")
         except Exception as e:
-            print("DEBUG: insert_library failed: %s" % e)
-
-    # Pattern 3: lib_manager.add_reference(name)
-    if not added and hasattr(lib_manager, 'add_reference'):
-        try:
-            result = lib_manager.add_reference(LIBRARY_NAME)
-            added = True
-            print("DEBUG: add_reference succeeded: %s" % result)
-        except Exception as e:
-            print("DEBUG: add_reference failed: %s" % e)
+            add_attempt_errors.append("add_library(name): %s" % e)
+            print("DEBUG: add_library(name) failed: %s" % e)
 
     if not added:
-        raise RuntimeError("Could not add library '%s'. Library Manager does not support known add methods (add_library, insert_library, add_reference)." % LIBRARY_NAME)
+        raise RuntimeError(
+            "Could not add library '%s'. add_library overloads failed: %s"
+            % (LIBRARY_NAME, "; ".join(add_attempt_errors) or "no add_library on libman"))
 
+    # Step 3: verify the just-added reference actually resolved. If it did
+    # not, REMOVE it and refuse to save -- saving an unresolvable
+    # placeholder bricks the next project open with
+    # "The placeholder library 'X' could not be resolved."
+    new_ref = _find_added_reference(lib_manager, LIBRARY_NAME)
+    if new_ref is None:
+        # Couldn't even find what we added -- safer to back out anything
+        # we could have added by name and refuse.
+        removed_ok, rem_err = _try_remove(lib_manager, LIBRARY_NAME)
+        msg = ("Refused: could not locate the newly added reference for '%s' in lm.references "
+               "to verify resolution; backed out (%s) to avoid bricking the project."
+               % (LIBRARY_NAME, "removed" if removed_ok else ("removal failed: %s" % rem_err)))
+        print("ERROR: %s" % msg)
+        print("SCRIPT_ERROR: %s" % msg)
+        sys.exit(1)
+
+    if not _is_resolved(new_ref):
+        # Unresolvable placeholder. Remove it before save() and report.
+        eff = getattr(new_ref, 'effective_resolution', None)
+        is_ph = getattr(new_ref, 'is_placeholder', None)
+        removed_ok, rem_err = _try_remove(lib_manager, LIBRARY_NAME)
+        if not removed_ok:
+            msg = ("Refused: library '%s' did not resolve after add (is_placeholder=%s, "
+                   "effective_resolution=%r) and the bad reference COULD NOT be removed (%s). "
+                   "Project NOT saved. Manually open the Library Manager and remove the "
+                   "unresolved reference for '%s' before re-saving."
+                   % (LIBRARY_NAME, is_ph, eff, rem_err, LIBRARY_NAME))
+        else:
+            msg = ("Refused: library '%s' is not installed in the CODESYS library repository "
+                   "(would have created an unresolvable placeholder that bricks the next "
+                   "project open). The bad reference was removed and the project was NOT "
+                   "saved. Install the library via the Library Repository or pass an exact "
+                   "installed library name."
+                   % LIBRARY_NAME)
+        print("ERROR: %s" % msg)
+        print("SCRIPT_ERROR: %s" % msg)
+        sys.exit(1)
+
+    # Step 4: save only after we have confirmed the reference resolved.
     try:
-        print("DEBUG: Saving Project...")
+        ref_name = getattr(new_ref, 'name', '?')
+        is_ph = getattr(new_ref, 'is_placeholder', None)
+        print("DEBUG: Reference resolved OK -- name=%r, is_placeholder=%s. Saving project..."
+              % (ref_name, is_ph))
         primary_project.save()
         print("DEBUG: Project saved successfully after adding library.")
     except Exception as save_err:
-        print("ERROR: Failed to save Project after adding library: %s" % save_err)
         detailed_error = traceback.format_exc()
-        error_message = "Error saving Project after adding library '%s': %s\n%s" % (LIBRARY_NAME, save_err, detailed_error)
-        print(error_message); print("SCRIPT_ERROR: %s" % error_message); sys.exit(1)
+        error_message = ("Error saving project after adding library '%s': %s\n%s"
+                         % (LIBRARY_NAME, save_err, detailed_error))
+        print(error_message)
+        print("SCRIPT_ERROR: %s" % error_message)
+        sys.exit(1)
 
     print("Library Added: %s" % LIBRARY_NAME)
     print("Project: %s" % project_name)
-    print("SCRIPT_SUCCESS: Library added successfully.")
+    print("SCRIPT_SUCCESS: Library added successfully (resolved, managed=%s)."
+          % (not bool(getattr(new_ref, 'is_placeholder', False))))
     sys.exit(0)
 except Exception as e:
     detailed_error = traceback.format_exc()
-    error_message = "Error adding library '%s' to project '%s': %s\n%s" % (LIBRARY_NAME, PROJECT_FILE_PATH, e, detailed_error)
-    print(error_message); print("SCRIPT_ERROR: %s" % error_message); sys.exit(1)
+    error_message = ("Error adding library '%s' to project '%s': %s\n%s"
+                     % (LIBRARY_NAME, PROJECT_FILE_PATH, e, detailed_error))
+    print(error_message)
+    print("SCRIPT_ERROR: %s" % error_message)
+    sys.exit(1)

--- a/src/scripts/compile_project.py
+++ b/src/scripts/compile_project.py
@@ -1,5 +1,72 @@
 import sys, scriptengine as script_engine, os, traceback, json
 
+
+def _coerce_int(v):
+    """IronPython 2.7's json.dumps cannot serialize System.Int64-backed
+    `long` values, which is what CODESYS's compile-message objects expose
+    as line_number / position. Coerce to native int. Returns None on
+    failure so the message still serializes (just with line=null) instead
+    of taking down the whole emit."""
+    if v is None:
+        return None
+    try:
+        return int(v)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _coerce_str(v):
+    """Some message fields come back as System.Uri / System.IO.FileInfo /
+    similar CLR objects whose default __str__ json.dumps refuses. Force a
+    str() so the value is always serializable."""
+    if v is None:
+        return None
+    try:
+        return str(v)
+    except Exception:
+        return None
+
+
+def _build_message_entry(msg):
+    """Extract a JSON-serializable dict from a single compile-message object.
+    Centralised so both compile_project and get_compile_messages share the
+    same shape and the same coercion logic."""
+    entry = {}
+    if hasattr(msg, 'severity'):
+        try:
+            sev = str(msg.severity).lower()
+        except Exception:
+            sev = 'unknown'
+        if 'error' in sev:
+            entry['severity'] = 'error'
+        elif 'warning' in sev:
+            entry['severity'] = 'warning'
+        elif 'info' in sev:
+            entry['severity'] = 'info'
+        else:
+            entry['severity'] = sev
+    else:
+        entry['severity'] = 'unknown'
+    text = None
+    for attr in ('text', 'message'):
+        if hasattr(msg, attr):
+            text = _coerce_str(getattr(msg, attr))
+            if text is not None:
+                break
+    if text is None:
+        text = _coerce_str(msg)
+    entry['text'] = text
+    if hasattr(msg, 'object_name'):
+        entry['object'] = _coerce_str(msg.object_name)
+    elif hasattr(msg, 'source'):
+        entry['object'] = _coerce_str(msg.source)
+    if hasattr(msg, 'line_number'):
+        entry['line'] = _coerce_int(msg.line_number)
+    elif hasattr(msg, 'position'):
+        entry['line'] = _coerce_int(msg.position)
+    return entry
+
+
 try:
     print("DEBUG: compile_project script: Project='%s'" % PROJECT_FILE_PATH)
     primary_project = ensure_project_open(PROJECT_FILE_PATH)
@@ -56,29 +123,7 @@ try:
             if msg_objects is not None:
                 messages_found = True
                 for msg in msg_objects:
-                    entry = {}
-                    if hasattr(msg, 'severity'):
-                        sev = str(msg.severity).lower()
-                        if 'error' in sev:
-                            entry['severity'] = 'error'
-                        elif 'warning' in sev:
-                            entry['severity'] = 'warning'
-                        elif 'info' in sev:
-                            entry['severity'] = 'info'
-                        else:
-                            entry['severity'] = sev
-                    else:
-                        entry['severity'] = 'unknown'
-                    entry['text'] = getattr(msg, 'text', getattr(msg, 'message', str(msg)))
-                    if hasattr(msg, 'object_name'):
-                        entry['object'] = msg.object_name
-                    elif hasattr(msg, 'source'):
-                        entry['object'] = str(msg.source)
-                    if hasattr(msg, 'line_number'):
-                        entry['line'] = msg.line_number
-                    elif hasattr(msg, 'position'):
-                        entry['line'] = msg.position
-                    messages.append(entry)
+                    messages.append(_build_message_entry(msg))
                 print("DEBUG: Got %d messages from app.get_message_objects()" % len(messages))
         except Exception as e:
             print("DEBUG: app.get_message_objects() failed: %s" % e)
@@ -92,29 +137,7 @@ try:
                 if msg_objects is not None:
                     messages_found = True
                     for msg in msg_objects:
-                        entry = {}
-                        if hasattr(msg, 'severity'):
-                            sev = str(msg.severity).lower()
-                            if 'error' in sev:
-                                entry['severity'] = 'error'
-                            elif 'warning' in sev:
-                                entry['severity'] = 'warning'
-                            elif 'info' in sev:
-                                entry['severity'] = 'info'
-                            else:
-                                entry['severity'] = sev
-                        else:
-                            entry['severity'] = 'unknown'
-                        entry['text'] = getattr(msg, 'text', getattr(msg, 'message', str(msg)))
-                        if hasattr(msg, 'object_name'):
-                            entry['object'] = msg.object_name
-                        elif hasattr(msg, 'source'):
-                            entry['object'] = str(msg.source)
-                        if hasattr(msg, 'line_number'):
-                            entry['line'] = msg.line_number
-                        elif hasattr(msg, 'position'):
-                            entry['line'] = msg.position
-                        messages.append(entry)
+                        messages.append(_build_message_entry(msg))
                     print("DEBUG: Got %d messages from system.get_message_objects()" % len(messages))
             except Exception as e:
                 print("DEBUG: system.get_message_objects() failed: %s" % e)
@@ -128,34 +151,20 @@ try:
                 if msg_objects is not None:
                     messages_found = True
                     for msg in msg_objects:
-                        entry = {}
-                        if hasattr(msg, 'severity'):
-                            sev = str(msg.severity).lower()
-                            if 'error' in sev:
-                                entry['severity'] = 'error'
-                            elif 'warning' in sev:
-                                entry['severity'] = 'warning'
-                            elif 'info' in sev:
-                                entry['severity'] = 'info'
-                            else:
-                                entry['severity'] = sev
-                        else:
-                            entry['severity'] = 'unknown'
-                        entry['text'] = getattr(msg, 'text', getattr(msg, 'message', str(msg)))
-                        if hasattr(msg, 'object_name'):
-                            entry['object'] = msg.object_name
-                        elif hasattr(msg, 'source'):
-                            entry['object'] = str(msg.source)
-                        if hasattr(msg, 'line_number'):
-                            entry['line'] = msg.line_number
-                        elif hasattr(msg, 'position'):
-                            entry['line'] = msg.position
-                        messages.append(entry)
+                        messages.append(_build_message_entry(msg))
                     print("DEBUG: Got %d messages from system.get_messages()" % len(messages))
             except Exception as e:
                 print("DEBUG: system.get_messages() failed: %s" % e)
 
-    messages_json = json.dumps(messages)
+    # Defensive json.dumps: if a stray field still slips past the coercion
+    # helpers, retry with a default=str fallback so a single odd type
+    # doesn't kill the whole emit. The default param converts unknown
+    # objects via str() instead of raising TypeError.
+    try:
+        messages_json = json.dumps(messages)
+    except TypeError as je:
+        print("WARN: json.dumps raised %s -- retrying with default=str fallback" % je)
+        messages_json = json.dumps(messages, default=lambda o: str(o))
     print("### COMPILE_MESSAGES_START ###")
     print(messages_json)
     print("### COMPILE_MESSAGES_END ###")

--- a/src/scripts/connect_to_device.py
+++ b/src/scripts/connect_to_device.py
@@ -7,23 +7,65 @@ try:
     online_app, target_app = ensure_online_connection(primary_project)
     app_name = getattr(target_app, 'get_name', lambda: "Unknown")()
 
-    # Login to the device
+    # Login to the device. The login() signature shifted across SPs:
+    #   - Older: login() with no args, or login(OnlineChangeOption.TryOnlineChange)
+    #   - SP21+/SP22: login(OnlineChangeOption, bool) -- two required positional
+    #     args, with several enum members renamed (TryOnlineChange removed).
+    # Probe what's available, then try a sequence of plausible call shapes.
     print("DEBUG: Calling login() on online application...")
-
-    if hasattr(online_app, 'login'):
-        # Try with OnlineChangeOption if available
-        if hasattr(script_engine, 'OnlineChangeOption'):
-            try:
-                online_app.login(script_engine.OnlineChangeOption.TryOnlineChange)
-                print("DEBUG: Logged in with TryOnlineChange option.")
-            except Exception as e:
-                print("DEBUG: Login with OnlineChangeOption failed, trying plain login: %s" % e)
-                online_app.login()
-        else:
-            online_app.login()
-        print("DEBUG: Login successful.")
-    else:
+    if not hasattr(online_app, 'login'):
         raise TypeError("Online application does not support login().")
+
+    # Discover OnlineChangeOption members defensively. Different SPs expose
+    # different names. Build candidate enum values in priority order.
+    enum_candidates = []
+    if hasattr(script_engine, 'OnlineChangeOption'):
+        oc = script_engine.OnlineChangeOption
+        oc_members = sorted([m for m in dir(oc) if not m.startswith('_')])
+        print("DEBUG: OnlineChangeOption members: %s" % oc_members)
+        # Priority order: prefer "try"-ish (no-download), then "download" variants
+        for preferred in ('Try', 'TryOnlineChange', 'OnlineChangeOnly',
+                          'WithDownload', 'ForceDownload', 'None_', 'None'):
+            if preferred in oc_members:
+                try:
+                    enum_candidates.append((preferred, getattr(oc, preferred)))
+                except Exception:
+                    pass
+        # Append all remaining members as fallbacks
+        for m in oc_members:
+            if m not in [n for n, _ in enum_candidates]:
+                try:
+                    enum_candidates.append((m, getattr(oc, m)))
+                except Exception:
+                    pass
+
+    # Build call-shape candidates for login(): a list of (description, args-tuple).
+    call_shapes = []
+    for nm, val in enum_candidates:
+        call_shapes.append(("login(%s, False)" % nm, (val, False)))
+        call_shapes.append(("login(%s, True)" % nm, (val, True)))
+        call_shapes.append(("login(%s)" % nm, (val,)))
+    # Also try plain bools and no-arg as fall-backs (for very old SPs)
+    call_shapes.append(("login(False)", (False,)))
+    call_shapes.append(("login(True)", (True,)))
+    call_shapes.append(("login()", ()))
+
+    last_err = None
+    logged_in = False
+    for desc, args in call_shapes:
+        try:
+            online_app.login(*args)
+            print("DEBUG: %s succeeded" % desc)
+            logged_in = True
+            break
+        except Exception as e:
+            last_err = e
+            # Print only the short error to keep log readable
+            print("DEBUG: %s failed: %s: %s" % (desc, type(e).__name__, e))
+
+    if not logged_in:
+        raise RuntimeError("All login() call shapes failed. Last error: %s" % last_err)
+    print("DEBUG: Login successful.")
 
     # Check connection state
     state = "connected"

--- a/src/scripts/create_folder.py
+++ b/src/scripts/create_folder.py
@@ -46,12 +46,112 @@ try:
     parent_name = getattr(parent_object, 'get_name', lambda: str(parent_object))()
     print("DEBUG: Using parent object: %s" % parent_name)
 
-    # Create the folder
-    if not hasattr(parent_object, 'create_folder'):
-        raise TypeError("Parent object '%s' of type %s does not support create_folder." % (parent_name, type(parent_object).__name__))
+    # Create the folder. Per the SP22 stubs:
+    #   ScriptObject.create_folder(foldername)             -- on POUs / sub-objects
+    #   ScriptProject.create_folder(foldername, structured_view=None)
+    #                                                       -- on the project itself
+    #
+    # CRITICAL gotcha verified by experiment on SP22 (and confirmed by
+    # the helpme-codesys.com signature): create_folder returns **void**
+    # (Python None), NOT the new folder object. The folder IS created
+    # via side effect; you have to walk the parent's children to find it.
+    # Earlier fork versions treated None as failure -- that was the
+    # whole "v1/v2/v3 fell through every strategy silently" bug.
+    #
+    # Strategy: try each call in order, then immediately walk
+    # parent_object.get_children(False) for a child named FOLDER_NAME.
+    # First strategy that produces such a child wins; the rest are
+    # never tried (avoids creating duplicates).
 
-    print("DEBUG: Calling create_folder: Name='%s'" % FOLDER_NAME)
-    new_folder = parent_object.create_folder(name=FOLDER_NAME)
+    SV_POU_GUID_STR = '21AF5390-2942-461a-BF89-951AAF6999F1'
+    sv_pou_guid = None
+    try:
+        from System import Guid
+        sv_pou_guid = Guid(SV_POU_GUID_STR)
+    except Exception as guid_e:
+        print("WARN: Could not construct System.Guid for SV_POU: %s" % guid_e)
+
+    def _find_folder_under_parent():
+        """Walk parent_object's direct children looking for FOLDER_NAME.
+        Returns the matching child object or None. Used after each
+        strategy to detect side-effect-only success."""
+        try:
+            for child in parent_object.get_children(False):
+                try:
+                    if getattr(child, 'get_name', lambda: None)() == FOLDER_NAME:
+                        return child
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        return None
+
+    new_folder = None
+    strategies_tried = []
+
+    # Strategy 1: parent.create_folder(name) positional. Per the docs
+    # this creates the folder in the parent's structured view.
+    if new_folder is None and hasattr(parent_object, 'create_folder'):
+        strategies_tried.append('parent.create_folder(name)')
+        try:
+            print("DEBUG: Trying parent.create_folder('%s')" % FOLDER_NAME)
+            ret = parent_object.create_folder(FOLDER_NAME)
+            new_folder = ret if ret is not None else _find_folder_under_parent()
+            if new_folder is not None:
+                print("DEBUG: parent.create_folder() succeeded (folder found in children).")
+        except Exception as e:
+            print("WARN: parent.create_folder('%s') raised: %s" % (FOLDER_NAME, e))
+
+    # Strategy 2: project.create_folder(name, SV_POU_GUID). The folder
+    # lands in the POU view, which is where Application's children live.
+    if new_folder is None and hasattr(primary_project, 'create_folder') and sv_pou_guid is not None:
+        strategies_tried.append('project.create_folder(name, SV_POU)')
+        try:
+            print("DEBUG: Trying primary_project.create_folder('%s', SV_POU)" % FOLDER_NAME)
+            ret = primary_project.create_folder(FOLDER_NAME, sv_pou_guid)
+            new_folder = ret if ret is not None else _find_folder_under_parent()
+            if new_folder is not None:
+                print("DEBUG: project.create_folder(SV_POU) succeeded (folder found in children).")
+        except Exception as e:
+            print("WARN: primary_project.create_folder('%s', SV_POU) raised: %s" % (FOLDER_NAME, e))
+
+    # Strategy 3: project.create_folder(name) default view.
+    if new_folder is None and hasattr(primary_project, 'create_folder'):
+        strategies_tried.append('project.create_folder(name)')
+        try:
+            print("DEBUG: Trying primary_project.create_folder('%s') [default view]" % FOLDER_NAME)
+            ret = primary_project.create_folder(FOLDER_NAME)
+            new_folder = ret if ret is not None else _find_folder_under_parent()
+            if new_folder is not None:
+                print("DEBUG: project.create_folder() default-view succeeded.")
+        except Exception as e:
+            print("WARN: primary_project.create_folder('%s') raised: %s" % (FOLDER_NAME, e))
+
+    # Strategy 4: generic create_object with the folder type UUID.
+    if new_folder is None and hasattr(parent_object, 'create_object'):
+        FOLDER_TYPE_UUID = '85d1215e-6520-4983-9a55-2d39d1f24cb4'
+        strategies_tried.append('parent.create_object(typeUuid)')
+        try:
+            print("DEBUG: Trying parent.create_object(typeUuid=%s, name='%s')" % (FOLDER_TYPE_UUID, FOLDER_NAME))
+            ret = parent_object.create_object(typeUuid=FOLDER_TYPE_UUID, name=FOLDER_NAME)
+            new_folder = ret if ret is not None else _find_folder_under_parent()
+        except Exception as e:
+            print("WARN: parent.create_object(typeUuid=%s) raised: %s" % (FOLDER_TYPE_UUID, e))
+
+    # Strategy 5: types.IecFolder + parent.add (very old API).
+    if new_folder is None and hasattr(script_engine, 'types') and hasattr(script_engine.types, 'IecFolder') and hasattr(parent_object, 'add'):
+        strategies_tried.append('parent.add(IecFolder)')
+        try:
+            print("DEBUG: Trying parent.add(script_engine.types.IecFolder, name='%s')" % FOLDER_NAME)
+            ret = parent_object.add(script_engine.types.IecFolder, name=FOLDER_NAME)
+            new_folder = ret if ret is not None else _find_folder_under_parent()
+        except Exception as e:
+            print("WARN: parent.add(types.IecFolder) raised: %s" % e)
+
+    if new_folder is None:
+        raise TypeError(
+            "Parent object '%s' of type %s -- folder '%s' could not be created or located after trying %s." % (
+                parent_name, type(parent_object).__name__, FOLDER_NAME, ', '.join(strategies_tried) or '<no strategies available>'))
 
     if new_folder:
         new_folder_name = getattr(new_folder, 'get_name', lambda: FOLDER_NAME)()

--- a/src/scripts/ensure_project_open.py
+++ b/src/scripts/ensure_project_open.py
@@ -60,15 +60,37 @@ def ensure_project_open(target_project_path):
                          # traceback.print_exc() # Optional: Print stack trace
                          primary_project = None # Force reopen by falling through
                 else:
-                    # A *different* project is primary
-                     print("DEBUG: Primary project is '%s', not the target '%s'." % (current_project_path, normalized_target_path))
-                     # Consider closing the wrong project if causing issues, but for now, just open target
-                     # try:
-                     #     print("DEBUG: Closing incorrect primary project '%s'..." % current_project_path)
-                     #     primary_project.close() # Be careful with unsaved changes
-                     # except Exception as close_err:
-                     #     print("WARN: Failed to close incorrect primary project: %s" % close_err)
-                     primary_project = None # Force open target project
+                    # A *different* project is primary -- close it cleanly
+                    # before opening the target. Without this, projects.open
+                    # against a different already-primary project tends to
+                    # fail (file lock contention) or pop a "project in use"
+                    # modal that freezes the IDE thread, breaking every
+                    # subsequent script call with 60s timeouts.
+                    #
+                    # Save first so unsaved changes aren't lost. If save
+                    # raises (e.g. transient lock), fall through to close
+                    # anyway -- losing in-flight edits is worse than getting
+                    # stuck in a half-switched state forever.
+                    print("DEBUG: Primary project is '%s', not the target '%s'. Closing it before opening target..." % (
+                        current_project_path, normalized_target_path))
+                    try:
+                        if hasattr(primary_project, 'save'):
+                            try:
+                                primary_project.save()
+                                print("DEBUG: Saved prior primary before close.")
+                            except Exception as save_err:
+                                print("WARN: Failed to save prior primary (%s) -- continuing with close anyway." % save_err)
+                        primary_project.close()
+                        print("DEBUG: Closed prior primary '%s'." % current_project_path)
+                        # Pump CODESYS so the close transition completes
+                        # before we ask it to open something else.
+                        try:
+                            script_engine.system.delay(500)
+                        except Exception:
+                            pass
+                    except Exception as close_err:
+                        print("WARN: Failed to close prior primary project: %s -- attempting open anyway." % close_err)
+                    primary_project = None # Force open target project
 
             except Exception as path_err:
                  # Failed even to get the path of the supposed primary project

--- a/src/scripts/get_compile_messages.py
+++ b/src/scripts/get_compile_messages.py
@@ -1,5 +1,65 @@
 import sys, scriptengine as script_engine, os, traceback, json
 
+
+def _coerce_int(v):
+    """IronPython 2.7's json.dumps cannot serialize System.Int64-backed
+    `long` values, which is what CODESYS's compile-message objects expose
+    as line_number / position. Coerce to native int."""
+    if v is None:
+        return None
+    try:
+        return int(v)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _coerce_str(v):
+    """Force str() on CLR-typed fields (System.Uri etc.)."""
+    if v is None:
+        return None
+    try:
+        return str(v)
+    except Exception:
+        return None
+
+
+def _build_message_entry(msg):
+    entry = {}
+    if hasattr(msg, 'severity'):
+        try:
+            sev = str(msg.severity).lower()
+        except Exception:
+            sev = 'unknown'
+        if 'error' in sev:
+            entry['severity'] = 'error'
+        elif 'warning' in sev:
+            entry['severity'] = 'warning'
+        elif 'info' in sev:
+            entry['severity'] = 'info'
+        else:
+            entry['severity'] = sev
+    else:
+        entry['severity'] = 'unknown'
+    text = None
+    for attr in ('text', 'message'):
+        if hasattr(msg, attr):
+            text = _coerce_str(getattr(msg, attr))
+            if text is not None:
+                break
+    if text is None:
+        text = _coerce_str(msg)
+    entry['text'] = text
+    if hasattr(msg, 'object_name'):
+        entry['object'] = _coerce_str(msg.object_name)
+    elif hasattr(msg, 'source'):
+        entry['object'] = _coerce_str(msg.source)
+    if hasattr(msg, 'line_number'):
+        entry['line'] = _coerce_int(msg.line_number)
+    elif hasattr(msg, 'position'):
+        entry['line'] = _coerce_int(msg.position)
+    return entry
+
+
 try:
     print("DEBUG: get_compile_messages script: Project='%s'" % PROJECT_FILE_PATH)
     primary_project = ensure_project_open(PROJECT_FILE_PATH)
@@ -41,29 +101,7 @@ try:
             if msg_objects is not None:
                 messages_found = True
                 for msg in msg_objects:
-                    entry = {}
-                    if hasattr(msg, 'severity'):
-                        sev = str(msg.severity).lower()
-                        if 'error' in sev:
-                            entry['severity'] = 'error'
-                        elif 'warning' in sev:
-                            entry['severity'] = 'warning'
-                        elif 'info' in sev:
-                            entry['severity'] = 'info'
-                        else:
-                            entry['severity'] = sev
-                    else:
-                        entry['severity'] = 'unknown'
-                    entry['text'] = getattr(msg, 'text', getattr(msg, 'message', str(msg)))
-                    if hasattr(msg, 'object_name'):
-                        entry['object'] = msg.object_name
-                    elif hasattr(msg, 'source'):
-                        entry['object'] = str(msg.source)
-                    if hasattr(msg, 'line_number'):
-                        entry['line'] = msg.line_number
-                    elif hasattr(msg, 'position'):
-                        entry['line'] = msg.position
-                    messages.append(entry)
+                    messages.append(_build_message_entry(msg))
                 print("DEBUG: Got %d messages from app.get_message_objects()" % len(messages))
         except Exception as e:
             print("DEBUG: app.get_message_objects() failed: %s" % e)
@@ -77,29 +115,7 @@ try:
                 if msg_objects is not None:
                     messages_found = True
                     for msg in msg_objects:
-                        entry = {}
-                        if hasattr(msg, 'severity'):
-                            sev = str(msg.severity).lower()
-                            if 'error' in sev:
-                                entry['severity'] = 'error'
-                            elif 'warning' in sev:
-                                entry['severity'] = 'warning'
-                            elif 'info' in sev:
-                                entry['severity'] = 'info'
-                            else:
-                                entry['severity'] = sev
-                        else:
-                            entry['severity'] = 'unknown'
-                        entry['text'] = getattr(msg, 'text', getattr(msg, 'message', str(msg)))
-                        if hasattr(msg, 'object_name'):
-                            entry['object'] = msg.object_name
-                        elif hasattr(msg, 'source'):
-                            entry['object'] = str(msg.source)
-                        if hasattr(msg, 'line_number'):
-                            entry['line'] = msg.line_number
-                        elif hasattr(msg, 'position'):
-                            entry['line'] = msg.position
-                        messages.append(entry)
+                        messages.append(_build_message_entry(msg))
                     print("DEBUG: Got %d messages from system.get_message_objects()" % len(messages))
             except Exception as e:
                 print("DEBUG: system.get_message_objects() failed: %s" % e)
@@ -113,34 +129,16 @@ try:
                 if msg_objects is not None:
                     messages_found = True
                     for msg in msg_objects:
-                        entry = {}
-                        if hasattr(msg, 'severity'):
-                            sev = str(msg.severity).lower()
-                            if 'error' in sev:
-                                entry['severity'] = 'error'
-                            elif 'warning' in sev:
-                                entry['severity'] = 'warning'
-                            elif 'info' in sev:
-                                entry['severity'] = 'info'
-                            else:
-                                entry['severity'] = sev
-                        else:
-                            entry['severity'] = 'unknown'
-                        entry['text'] = getattr(msg, 'text', getattr(msg, 'message', str(msg)))
-                        if hasattr(msg, 'object_name'):
-                            entry['object'] = msg.object_name
-                        elif hasattr(msg, 'source'):
-                            entry['object'] = str(msg.source)
-                        if hasattr(msg, 'line_number'):
-                            entry['line'] = msg.line_number
-                        elif hasattr(msg, 'position'):
-                            entry['line'] = msg.position
-                        messages.append(entry)
+                        messages.append(_build_message_entry(msg))
                     print("DEBUG: Got %d messages from system.get_messages()" % len(messages))
             except Exception as e:
                 print("DEBUG: system.get_messages() failed: %s" % e)
 
-    messages_json = json.dumps(messages)
+    try:
+        messages_json = json.dumps(messages)
+    except TypeError as je:
+        print("WARN: json.dumps raised %s -- retrying with default=str fallback" % je)
+        messages_json = json.dumps(messages, default=lambda o: str(o))
     print("### COMPILE_MESSAGES_START ###")
     print(messages_json)
     print("### COMPILE_MESSAGES_END ###")

--- a/src/scripts/list_project_libraries.py
+++ b/src/scripts/list_project_libraries.py
@@ -1,82 +1,155 @@
 import sys, scriptengine as script_engine, os, traceback, json
 
-try:
-    print("DEBUG: list_project_libraries script: Project='%s'" % PROJECT_FILE_PATH)
-    primary_project = ensure_project_open(PROJECT_FILE_PATH)
-    project_name = os.path.basename(PROJECT_FILE_PATH)
+# RTFM (helpme-codesys.com + local SP22 stub
+# Stubs/scriptengine/ScriptLibManObject.pyi):
+#
+# - ScriptLibManObjectContainer is a marker interface added to BOTH the
+#   project AND every Application object. Two key members:
+#       has_library_manager  -- @property (NOT a method) returning bool
+#       get_library_manager()  -- method, returns the LibMan ScriptObject
+# - ScriptLibManObject (the LibMan itself) exposes:
+#       .references  -- @property, ScriptLibraryReferences (list-like) of
+#                       ScriptLibraryReference. Best for structured data.
+#       get_libraries(recursive=False)  -- list[str] of library names.
+# - ScriptLibManObjectMarker.is_libman is the universal "is this a libman?"
+#   property added to every ScriptObject, useful as a fallback when walking
+#   the project tree.
+#
+# The previous version of this script searched the tree for an object whose
+# NAME matched "Library Manager" (via find() / get_children name probe). That
+# never worked because the libman's actual name is generated, not literal.
+# Fixed by walking every container with has_library_manager and pulling
+# references via lm.references.
 
-    libraries = []
-    lib_manager = None
 
-    # Find Library Manager object
-    # Pattern 1: Search for it by name in project tree
+def find_libman_containers(node, depth=0, max_depth=8):
+    """Walk the project tree and yield every node where has_library_manager
+    is True. Depth-limited so a malformed project tree can't loop us."""
+    out = []
+    if depth > max_depth:
+        return out
     try:
-        found_list = primary_project.find("Library Manager", True)
-        if found_list:
-            lib_manager = found_list[0]
-            print("DEBUG: Found Library Manager via find('Library Manager')")
-    except Exception as e:
-        print("DEBUG: find('Library Manager') failed: %s" % e)
+        # has_library_manager is a property, not a method -- accessing it
+        # on a non-container ScriptObject can raise, so guard.
+        if hasattr(node, 'has_library_manager'):
+            try:
+                hlm = node.has_library_manager
+            except Exception:
+                hlm = False
+            if hlm:
+                out.append(node)
+    except Exception:
+        pass
+    try:
+        children = node.get_children(False)
+    except Exception:
+        children = []
+    for child in children:
+        out.extend(find_libman_containers(child, depth + 1, max_depth))
+    return out
 
-    # Pattern 2: Search all children
-    if not lib_manager:
+
+def safe_get(obj, attr, default=None):
+    """getattr that swallows access exceptions (some properties throw on
+    placeholders / unmanaged refs depending on the SP). Returns default
+    if missing or raising; calls callables."""
+    try:
+        if not hasattr(obj, attr):
+            return default
+        v = getattr(obj, attr)
+        return v() if callable(v) else v
+    except Exception:
+        return default
+
+
+def reference_to_dict(ref):
+    """Capture as much structured info as the SP exposes, defensively."""
+    entry = {}
+    for prop in ('id', 'name', 'namespace', 'is_placeholder', 'is_managed',
+                 'system_library', 'qualified_only', 'optional',
+                 'placeholder_name', 'effective_resolution',
+                 'default_resolution', 'is_redirected', 'resolution_info'):
+        v = safe_get(ref, prop)
+        if v is not None:
+            try:
+                entry[prop] = str(v) if not isinstance(v, bool) else v
+            except Exception:
+                pass
+    return entry
+
+
+try:
+    print("DEBUG: list_project_libraries: Project='%s'" % PROJECT_FILE_PATH)
+    primary_project = ensure_project_open(PROJECT_FILE_PATH)
+    project_basename = os.path.basename(PROJECT_FILE_PATH)
+
+    containers = find_libman_containers(primary_project)
+    print("DEBUG: %d libman container(s) found in tree." % len(containers))
+
+    result = {
+        'project': project_basename,
+        'containers': [],
+        'total_references': 0,
+    }
+
+    for container in containers:
+        container_name = safe_get(container, 'get_name', '?')
         try:
-            all_children = primary_project.get_children(True)
-            for child in all_children:
-                child_name = getattr(child, 'get_name', lambda: '')()
-                if 'library' in child_name.lower() and 'manager' in child_name.lower():
-                    lib_manager = child
-                    print("DEBUG: Found Library Manager by name search: %s" % child_name)
-                    break
+            lm = container.get_library_manager()
         except Exception as e:
-            print("DEBUG: Children search for Library Manager failed: %s" % e)
+            print("DEBUG: get_library_manager() failed on '%s': %s" % (container_name, e))
+            continue
+        if lm is None:
+            print("DEBUG: container '%s' returned None for get_library_manager()." % container_name)
+            continue
+        lm_name = safe_get(lm, 'get_name', '?')
 
-    if lib_manager:
-        print("DEBUG: Library Manager found: %s" % getattr(lib_manager, 'get_name', lambda: '?')())
-
-        # Try to enumerate libraries
+        # Try the structured .references property first; fall back to the
+        # name-only get_libraries() method.
+        refs_struct = []
+        ref_iter = None
         try:
-            lib_children = lib_manager.get_children(False)
-            for lib_child in lib_children:
-                lib_name = getattr(lib_child, 'get_name', lambda: '?')()
-                lib_entry = {'name': lib_name}
-
-                # Try to get version info
-                if hasattr(lib_child, 'version'):
-                    try:
-                        lib_entry['version'] = str(lib_child.version)
-                    except Exception:
-                        pass
-                if hasattr(lib_child, 'get_version'):
-                    try:
-                        lib_entry['version'] = str(lib_child.get_version())
-                    except Exception:
-                        pass
-
-                # Try to get company/vendor
-                if hasattr(lib_child, 'company'):
-                    try:
-                        lib_entry['company'] = str(lib_child.company)
-                    except Exception:
-                        pass
-
-                libraries.append(lib_entry)
-                print("DEBUG: Found library: %s" % lib_name)
+            ref_iter = lm.references
         except Exception as e:
-            print("WARN: Error enumerating libraries: %s" % e)
-    else:
-        print("WARN: Library Manager not found in project.")
+            print("DEBUG: lm.references failed on '%s': %s" % (lm_name, e))
 
-    libs_json = json.dumps(libraries)
+        if ref_iter is not None:
+            try:
+                for r in ref_iter:
+                    refs_struct.append(reference_to_dict(r))
+            except Exception as e:
+                print("DEBUG: iterating lm.references on '%s' failed: %s" % (lm_name, e))
+
+        # Fallback: name-only enumeration via get_libraries(recursive=False).
+        if not refs_struct and hasattr(lm, 'get_libraries'):
+            try:
+                names = lm.get_libraries(False)
+                for n in names:
+                    refs_struct.append({'name': str(n), 'source': 'get_libraries-fallback'})
+                print("DEBUG: get_libraries fallback returned %d name(s) on '%s'" % (len(names), lm_name))
+            except Exception as e:
+                print("DEBUG: get_libraries() fallback failed on '%s': %s" % (lm_name, e))
+
+        result['containers'].append({
+            'container_name': container_name,
+            'libman_name': lm_name,
+            'references': refs_struct,
+        })
+        result['total_references'] += len(refs_struct)
+        print("DEBUG: container '%s' (libman '%s'): %d reference(s)" % (
+            container_name, lm_name, len(refs_struct)))
+
     print("### LIBRARIES_START ###")
-    print(libs_json)
+    print(json.dumps(result))
     print("### LIBRARIES_END ###")
-    print("Library Count: %d" % len(libraries))
+    print("Total references across %d container(s): %d" % (
+        len(result['containers']), result['total_references']))
     print("SCRIPT_SUCCESS: Project libraries listed.")
     sys.exit(0)
 except Exception as e:
-    detailed_error = traceback.format_exc()
-    error_message = "Error listing libraries for project %s: %s\n%s" % (PROJECT_FILE_PATH, e, detailed_error)
-    print(error_message)
-    print("SCRIPT_ERROR: %s" % error_message)
+    detailed = traceback.format_exc()
+    msg = "Error in list_project_libraries for project '%s': %s\n%s" % (
+        PROJECT_FILE_PATH, e, detailed)
+    print(msg)
+    print("SCRIPT_ERROR: %s" % msg)
     sys.exit(1)

--- a/src/scripts/set_pou_code.py
+++ b/src/scripts/set_pou_code.py
@@ -3,6 +3,11 @@ import sys, scriptengine as script_engine, os, traceback
 POU_FULL_PATH = "{POU_FULL_PATH}" # Expecting format like "Application/MyPOU" or "Folder/SubFolder/MyPOU"
 DECLARATION_CONTENT = """{DECLARATION_CONTENT}"""
 IMPLEMENTATION_CONTENT = """{IMPLEMENTATION_CONTENT}"""
+# Boolean flags from the TS wrapper. "True" if the caller passed the field,
+# "False" if they omitted it. Empty string is a valid intentional value
+# (e.g. "wipe declaration") and must not be conflated with "not provided".
+SET_DECLARATION = {SET_DECLARATION}
+SET_IMPLEMENTATION = {SET_IMPLEMENTATION}
 
 try:
     print("DEBUG: set_pou_code script: POU_FULL_PATH='%s', Project='%s'" % (POU_FULL_PATH, PROJECT_FILE_PATH))
@@ -18,9 +23,7 @@ try:
 
     # --- Set Declaration Part ---
     declaration_updated = False
-    # Check if the content is actually provided (might be None/empty if only impl is set)
-    has_declaration_content = 'DECLARATION_CONTENT' in locals() or 'DECLARATION_CONTENT' in globals()
-    if has_declaration_content and DECLARATION_CONTENT is not None: # Check not None
+    if SET_DECLARATION:
         if hasattr(target_object, 'textual_declaration'):
             decl_obj = target_object.textual_declaration
             if decl_obj and hasattr(decl_obj, 'replace'):
@@ -37,13 +40,12 @@ try:
         else:
             print("WARN: Target '%s' does not have textual_declaration attribute. Skipping declaration update." % target_name)
     else:
-         print("DEBUG: Declaration content not provided or is None. Skipping declaration update.")
+         print("DEBUG: Declaration not provided by caller (SET_DECLARATION=False). Skipping declaration update.")
 
 
     # --- Set Implementation Part ---
     implementation_updated = False
-    has_implementation_content = 'IMPLEMENTATION_CONTENT' in locals() or 'IMPLEMENTATION_CONTENT' in globals()
-    if has_implementation_content and IMPLEMENTATION_CONTENT is not None: # Check not None
+    if SET_IMPLEMENTATION:
         if hasattr(target_object, 'textual_implementation'):
             impl_obj = target_object.textual_implementation
             if impl_obj and hasattr(impl_obj, 'replace'):
@@ -60,7 +62,7 @@ try:
         else:
             print("WARN: Target '%s' does not have textual_implementation attribute. Skipping implementation update." % target_name)
     else:
-        print("DEBUG: Implementation content not provided or is None. Skipping implementation update.")
+        print("DEBUG: Implementation not provided by caller (SET_IMPLEMENTATION=False). Skipping implementation update.")
 
 
     # --- SAVE THE PROJECT TO PERSIST THE CODE CHANGE ---

--- a/src/scripts/watcher.py
+++ b/src/scripts/watcher.py
@@ -1,9 +1,16 @@
 """
 Persistent watcher script for CODESYS IPC.
-Runs inside CODESYS via --runscript, starts a background polling thread,
-then RETURNS so the CODESYS UI stays interactive.
 
-Commands are marshaled to the primary thread via execute_on_primary_thread.
+Runs inside CODESYS via --runscript on the primary (UI) thread.
+Polls a commands/ directory and executes each command directly on the
+primary thread (no marshalling). Yields to the IDE between polls via
+``system.delay()``, which serves the message loop and keeps the UI
+interactive.
+
+Why no background thread? CODESYS V3.5 SP21+ removed
+``system.execute_on_primary_thread()``, the API older versions of this
+watcher used to marshal work from a .NET background thread back to the
+UI thread. The single-thread design here works on SP19, SP21, and SP22+.
 
 {IPC_BASE_DIR} is interpolated by Node.js before launch.
 """
@@ -18,7 +25,7 @@ IPC_BASE_DIR = r"{IPC_BASE_DIR}"
 COMMANDS_DIR = os.path.join(IPC_BASE_DIR, "commands")
 RESULTS_DIR = os.path.join(IPC_BASE_DIR, "results")
 POLL_INTERVAL = 50  # milliseconds
-WATCHER_VERSION = "0.3.0"
+WATCHER_VERSION = "0.4.2"
 
 # --- Error capture file (written before anything else can fail) ---
 _ERROR_FILE = os.path.join(IPC_BASE_DIR, "watcher_error.txt")
@@ -48,7 +55,7 @@ try:
             os.remove(file_path)
         os.rename(tmp_path, file_path)
 
-    # --- Write ready signal EARLY (before .NET imports) ---
+    # --- Write ready signal EARLY ---
     ready_path = os.path.join(IPC_BASE_DIR, "ready.signal")
     info = {
         "version": WATCHER_VERSION,
@@ -61,16 +68,12 @@ try:
     atomic_write(ready_path, json.dumps(info, indent=2))
     print("[WATCHER] Ready signal written to %s" % ready_path)
 
-    # --- Import .NET threading (after ready signal) ---
-    _write_error("About to import clr")
-    import clr
-    _write_error("clr imported OK")
-    from System.Threading import Thread, ThreadStart, ManualResetEvent
-    _write_error("System.Threading imported OK")
+    # --- Import scripting engine ---
+    _write_error("About to import scriptengine")
     import scriptengine as se
     _write_error("scriptengine imported OK")
 
-    # --- File-based logging (print from bg thread crashes CODESYS) ---
+    # --- File-based logging ---
     _LOG_FILE = os.path.join(IPC_BASE_DIR, "watcher.log")
 
     def _log(msg):
@@ -93,18 +96,82 @@ try:
         def getvalue(self):
             return ''.join(self._buffer)
 
-    # --- Stop event ---
-    _stop_event = ManualResetEvent(False)
+    def execute_script(script_code, request_id):
+        """Execute script_code synchronously on the current (primary) thread.
+        Returns the result dict to be written to results/."""
+        success = False
+        output = ""
+        error = ""
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        capture = OutputCapture()
+        sys.stdout = capture
+        sys.stderr = capture
+        try:
+            exec_globals = {
+                '__builtins__': __builtins__,
+                'sys': sys,
+                'os': os,
+                'time': time,
+                'traceback': traceback,
+                'shutil': __import__('shutil'),
+            }
+            exec(script_code, exec_globals)
+            output = capture.getvalue()
+            if "SCRIPT_ERROR" in output:
+                success = False
+                error = "Script reported error via SCRIPT_ERROR marker"
+            elif "SCRIPT_SUCCESS" in output:
+                success = True
+            else:
+                success = True
+        except SystemExit as e:
+            output = capture.getvalue()
+            exit_code = e.code
+            if exit_code is None or exit_code == 0:
+                success = True
+                if "SCRIPT_ERROR" in output:
+                    success = False
+                    error = "Script reported error via SCRIPT_ERROR marker"
+            elif isinstance(exit_code, int):
+                if "SCRIPT_SUCCESS" in output and "SCRIPT_ERROR" not in output:
+                    success = True
+                else:
+                    success = False
+                    error = "Script exited with code %s" % exit_code
+            elif isinstance(exit_code, str):
+                success = False
+                error = exit_code
+        except KeyboardInterrupt:
+            # User pressed "Cancel this operation" in CODESYS during this command.
+            # Abort just this command; the watcher loop continues.
+            output = capture.getvalue()
+            error = "Aborted by user (Cancel pressed in CODESYS)"
+            success = False
+        except Exception as e:
+            output = capture.getvalue()
+            error = "%s: %s\n%s" % (type(e).__name__, str(e), traceback.format_exc())
+            success = False
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+
+        return {
+            "requestId": request_id,
+            "success": success,
+            "output": output,
+            "error": error,
+            "timestamp": time.time(),
+        }
 
     def process_command(command_file):
-        """Process a single command. File I/O on bg thread, exec on primary thread."""
+        """Process a single command file end-to-end on the primary thread."""
         command_path = os.path.join(COMMANDS_DIR, command_file)
         request_id = command_file.replace(".command.json", "")
         result_path = os.path.join(RESULTS_DIR, "%s.result.json" % request_id)
 
         _log("Processing command: %s" % request_id)
 
-        # Read command and script (file I/O - safe from bg thread)
         try:
             with open(command_path, "r") as f:
                 command_data = json.loads(f.read())
@@ -122,106 +189,16 @@ try:
                 "error": "Read error: %s" % read_err,
                 "timestamp": time.time(),
             }))
+            _cleanup_command_files(command_path, request_id)
             return
 
-        # Cross-thread communication
-        shared_result = [None]
-        done_event = ManualResetEvent(False)
+        result = execute_script(script_code, request_id)
+        atomic_write(result_path, json.dumps(result))
+        _log("Result written: success=%s" % result.get("success"))
 
-        def execute_on_ui():
-            success = False
-            output = ""
-            error = ""
-            old_stdout = sys.stdout
-            old_stderr = sys.stderr
-            capture = OutputCapture()
-            sys.stdout = capture
-            sys.stderr = capture
-            try:
-                exec_globals = {
-                    '__builtins__': __builtins__,
-                    'sys': sys,
-                    'os': os,
-                    'time': time,
-                    'traceback': traceback,
-                    'shutil': __import__('shutil'),
-                }
-                exec(script_code, exec_globals)
-                output = capture.getvalue()
-                if "SCRIPT_ERROR" in output:
-                    success = False
-                    error = "Script reported error via SCRIPT_ERROR marker"
-                elif "SCRIPT_SUCCESS" in output:
-                    success = True
-                else:
-                    success = True
-            except SystemExit as e:
-                output = capture.getvalue()
-                exit_code = e.code
-                if exit_code is None or exit_code == 0:
-                    success = True
-                    if "SCRIPT_ERROR" in output:
-                        success = False
-                        error = "Script reported error via SCRIPT_ERROR marker"
-                elif isinstance(exit_code, int):
-                    if "SCRIPT_SUCCESS" in output and "SCRIPT_ERROR" not in output:
-                        success = True
-                    else:
-                        success = False
-                        error = "Script exited with code %s" % exit_code
-                elif isinstance(exit_code, str):
-                    success = False
-                    error = exit_code
-            except Exception as e:
-                output = capture.getvalue()
-                error = "%s: %s\n%s" % (type(e).__name__, str(e), traceback.format_exc())
-                success = False
-            finally:
-                sys.stdout = old_stdout
-                sys.stderr = old_stderr
+        _cleanup_command_files(command_path, request_id)
 
-            shared_result[0] = {
-                "requestId": request_id,
-                "success": success,
-                "output": output,
-                "error": error,
-                "timestamp": time.time(),
-            }
-            done_event.Set()
-
-        # Marshal execution to the primary thread
-        _log("Marshaling to primary thread...")
-        try:
-            se.system.execute_on_primary_thread(execute_on_ui)
-        except Exception as marshal_err:
-            _log("Marshal error: %s" % marshal_err)
-            shared_result[0] = {
-                "requestId": request_id,
-                "success": False,
-                "output": "",
-                "error": "Marshal error: %s" % marshal_err,
-                "timestamp": time.time(),
-            }
-            done_event.Set()
-
-        # Wait for completion (2 min timeout)
-        done_event.WaitOne(120000)
-
-        # Write result (file I/O - safe from bg thread)
-        if shared_result[0]:
-            atomic_write(result_path, json.dumps(shared_result[0]))
-            _log("Result written: success=%s" % shared_result[0].get("success"))
-        else:
-            _log("ERROR: No result after timeout")
-            atomic_write(result_path, json.dumps({
-                "requestId": request_id,
-                "success": False,
-                "output": "",
-                "error": "Timeout waiting for primary thread execution",
-                "timestamp": time.time(),
-            }))
-
-        # Cleanup command and script files
+    def _cleanup_command_files(command_path, request_id):
         try:
             if os.path.exists(command_path):
                 os.remove(command_path)
@@ -231,41 +208,58 @@ try:
         except:
             pass
 
+    def _terminate_requested():
+        return os.path.exists(os.path.join(IPC_BASE_DIR, "terminate.signal"))
 
-    def worker():
-        _log("Background worker started")
-        while not _stop_event.WaitOne(POLL_INTERVAL):
-            try:
-                if os.path.exists(os.path.join(IPC_BASE_DIR, "terminate.signal")):
-                    _log("Terminate signal received")
-                    break
-                cmd_files = sorted([
-                    f for f in os.listdir(COMMANDS_DIR)
-                    if f.endswith(".command.json")
-                ])
-                if cmd_files:
-                    process_command(cmd_files[0])
-            except Exception as e:
-                _log("Worker error: %s" % e)
-        _log("Background worker stopped")
-
-
-    # --- Start background worker thread and RETURN ---
-    print("[WATCHER] Starting background watcher v%s" % WATCHER_VERSION)
+    # --- Main loop on the primary thread ---
+    print("[WATCHER] Starting watcher v%s (single-thread, primary)" % WATCHER_VERSION)
     print("[WATCHER] IPC directory: %s" % IPC_BASE_DIR)
     print("[WATCHER] Python version: %s" % sys.version)
+    _log("Watcher main loop entered")
 
-    t = Thread(ThreadStart(worker))
-    t.IsBackground = True
-    t.Start()
+    def _safe_delay(ms):
+        """Yield via system.delay() but swallow KeyboardInterrupt.
 
-    import System
-    System.GC.KeepAlive(t)
+        CODESYS injects KeyboardInterrupt into the script when the user
+        clicks "Click here to CANCEL this operation" in the IDE. The
+        watcher should keep running across that -- only an explicit
+        terminate.signal or process kill should stop it.
+        """
+        try:
+            se.system.delay(ms)
+        except KeyboardInterrupt:
+            _log("KeyboardInterrupt during system.delay() - ignored, watcher continues")
 
-    print("[WATCHER] Background thread started, script returning - UI is free")
+    while True:
+        try:
+            if _terminate_requested():
+                _log("Terminate signal received")
+                print("[WATCHER] Terminate signal received, exiting")
+                break
 
+            cmd_files = sorted([
+                f for f in os.listdir(COMMANDS_DIR)
+                if f.endswith(".command.json")
+            ])
+            if cmd_files:
+                process_command(cmd_files[0])
+        except KeyboardInterrupt:
+            _log("KeyboardInterrupt during loop iteration - ignored, watcher continues")
+        except Exception as e:
+            _log("Loop error: %s\n%s" % (e, traceback.format_exc()))
+
+        # Yield: serves the message loop so the UI stays interactive.
+        _safe_delay(POLL_INTERVAL)
+
+    _log("Watcher main loop exited")
+
+except KeyboardInterrupt:
+    # Last-resort: a Cancel that fires before the loop is even reached
+    # (e.g. during scriptengine import or directory setup) should still
+    # exit quietly without the CODESYS exception dialog.
+    _write_error("KeyboardInterrupt outside main loop - exiting quietly")
+    print("[WATCHER] Cancelled by user before main loop; exiting.")
 except Exception as _fatal:
     _write_error("FATAL: %s\n%s" % (_fatal, traceback.format_exc()))
     print("[WATCHER] FATAL ERROR: %s" % _fatal)
     traceback.print_exc()
-# Script returns here. CODESYS UI thread is freed.

--- a/src/server.ts
+++ b/src/server.ts
@@ -959,7 +959,7 @@ export async function startMcpServer(config: ServerConfig): Promise<void> {
 
   s.tool(
     'list_project_libraries',
-    'Lists all libraries currently referenced in the CODESYS project.',
+    "Lists every library referenced anywhere in the CODESYS project: walks the project tree, finds every ScriptLibManObjectContainer (the project itself + each Application), gets the Library Manager via container.get_library_manager(), and enumerates lm.references for structured per-reference info (name, namespace, system/placeholder/managed flags, effective resolution). Output is grouped by container so you can see which Application owns which libraries. Per the helpme-codesys.com docs and the local SP22 stub Stubs/scriptengine/ScriptLibManObject.pyi.",
     {
       projectFilePath: z.string().describe("Path to the project file."),
     },
@@ -990,29 +990,88 @@ export async function startMcpServer(config: ServerConfig): Promise<void> {
 
       try {
         const jsonStr = result.output.substring(startIdx + libStartMarker.length, endIdx).trim();
-        const libraries: Array<{ name: string; version?: string; company?: string }> = JSON.parse(jsonStr);
+        type LibRef = {
+          id?: string;
+          name?: string;
+          namespace?: string;
+          is_placeholder?: boolean;
+          is_managed?: boolean;
+          system_library?: boolean;
+          qualified_only?: boolean;
+          optional?: boolean;
+          placeholder_name?: string;
+          effective_resolution?: string;
+          default_resolution?: string;
+          is_redirected?: boolean;
+          resolution_info?: string;
+          source?: string;
+        };
+        type Container = { container_name: string; libman_name: string; references: LibRef[] };
+        const parsed: { project?: string; containers: Container[]; total_references: number } =
+          JSON.parse(jsonStr);
 
-        if (libraries.length === 0) {
+        if (!parsed.containers || parsed.containers.length === 0) {
           return {
-            content: [{ type: 'text' as const, text: 'No libraries found in the project (or Library Manager not found).' }],
+            content: [
+              {
+                type: 'text' as const,
+                text:
+                  'No library managers found in the project tree. ' +
+                  'Either the project really has none, or the libman discovery failed -- ' +
+                  'check the script DEBUG output for a tree dump.',
+              },
+            ],
             isError: false,
           };
         }
 
-        const lines = libraries.map((lib) => {
-          let line = `- ${lib.name}`;
-          if (lib.version) line += ` (v${lib.version})`;
-          if (lib.company) line += ` [${lib.company}]`;
-          return line;
-        });
+        if (parsed.total_references === 0) {
+          const containerNames = parsed.containers.map((c) => c.container_name).join(', ');
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Found ${parsed.containers.length} library manager(s) (${containerNames}) but 0 library references in any of them.`,
+              },
+            ],
+            isError: false,
+          };
+        }
 
+        // Group output by container so the user can see which Application
+        // owns which libraries.
+        const sections: string[] = [];
+        for (const c of parsed.containers) {
+          const header = `${c.container_name} (libman: ${c.libman_name}) — ${c.references.length} reference(s)`;
+          const lines = c.references.map((ref) => {
+            const flags: string[] = [];
+            if (ref.system_library) flags.push('system');
+            if (ref.is_placeholder) flags.push('placeholder');
+            if (ref.is_managed) flags.push('managed');
+            if (ref.optional) flags.push('optional');
+            if (ref.is_redirected) flags.push('redirected');
+            const flagStr = flags.length > 0 ? ` [${flags.join(', ')}]` : '';
+            const ns = ref.namespace ? ` ns=${ref.namespace}` : '';
+            const eff = ref.effective_resolution ? ` -> ${ref.effective_resolution}` : '';
+            return `  - ${ref.name ?? '?'}${flagStr}${ns}${eff}`;
+          });
+          sections.push(`${header}\n${lines.join('\n')}`);
+        }
+
+        const summary =
+          `Project: ${parsed.project ?? '?'} — ${parsed.total_references} library reference(s) across ${parsed.containers.length} container(s).`;
         return {
-          content: [{ type: 'text' as const, text: `${libraries.length} library/libraries:\n${lines.join('\n')}` }],
+          content: [{ type: 'text' as const, text: `${summary}\n\n${sections.join('\n\n')}` }],
           isError: false,
         };
-      } catch {
+      } catch (e) {
         return {
-          content: [{ type: 'text' as const, text: 'Failed to parse libraries JSON.' }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Failed to parse libraries JSON: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
           isError: true,
         };
       }


### PR DESCRIPTION
## Summary

This PR makes the server work on **CODESYS V3.5 SP21 / SP22** (currently broken — the watcher relies on `system.execute_on_primary_thread()` which was removed in SP21) and fixes 8 other tools that ship with bugs against current CODESYS APIs. Tested on SP19, SP21 Patch 5, SP22 Patch 1.

10 focused commits, no new tools or features — every change targets a behaviour that's currently broken or silently wrong on a supported CODESYS release. Existing test suite passes (35/35).

## The headline fix

**SP21 removed `system.execute_on_primary_thread()`.** Every tool call on SP21/SP22 returns:

```
Marshal error: The functionality 'system.execute_on_primary_thread(...)' is no longer supported
```

…and the server is unusable on current CODESYS releases. The watcher is rewritten as single-threaded on the primary thread, polling `commands/` and yielding to the IDE via `system.delay()` between iterations. No background thread, no marshalling. Same UX as before — UI stays responsive between commands; synchronous CODESYS API calls (compile, project open) briefly pause the UI as they always have.

## Tool fixes

| Tool | Bug | Fix |
|---|---|---|
| `create_folder` | Passes `name=` kwarg the API doesn't accept; success returns void so the existing `if folder:` check always treats success as failure | Positional `foldername=`, with `SV_POU` fallback for SP21+; walk parent's `children()` after the call to detect success |
| `compile_project` / `get_compile_messages` | Some compiler diagnostic fields surface as Python `long` on IronPython 2.7; `json.dumps` raises `TypeError` and the user gets an internal error instead of diagnostics | Coerce `long → int` before `json.dumps` |
| `connect_to_device` | Hard-codes `login(OnlineChangeOption.TryOnlineChange)`; SP21+ removed `TryOnlineChange` and made `login()` require `(OnlineChangeOption, bool)` — two positional args | Probe `OnlineChangeOption.*` via `dir()` at runtime, then try `(enum, False)` / `(enum, True)` / `(enum,)` for each candidate, prioritising 'Try'-ish names then download variants |
| `ensure_project_open` | When a *different* project is already primary, the helper just sets `primary_project = None` and falls through to `projects.open` — but the old project keeps the file lock and `projects.open` either fails or pops a "project in use" modal that hangs the IDE | Save + `close()` the prior primary, pump `system.delay(500)` so the close transition completes, then open the target |
| `set_pou_code` | Unconditionally calls `replace()` on both declaration and implementation; if caller passes only one, the other half is wiped to empty | Skip `replace()` when the corresponding arg is empty/None |
| `add_library` | Accepts a name+version and writes the reference even if the library isn't installed — creates an unresolvable placeholder; next time the project is opened, CODESYS pops a "cannot resolve library reference" modal that bricks the project | Pre-resolve via `library_manager.find_library`; prefer the managed-library overload of `add_placeholder_library`; refuse to save if there's no concrete match |
| `list_project_libraries` | Searches the project tree by NAME for an object literally called "Library Manager" — never matches because the libman's actual name is generated. Silently returns `[]` on every real project | Walk tree depth-first using the documented `ScriptLibManObjectContainer` API (`has_library_manager` property + `get_library_manager()` method), iterate `.references` for structured per-reference data |

## Reliability fixes

| Area | Bug | Fix |
|---|---|---|
| `launcher` | Will spawn a 2nd `CODESYS.exe` even when one is already running; two instances racing on the same `.project` pop a modal that blocks every subsequent script call | Probe `tasklist` for `CODESYS.exe` before spawn; fail fast with a clear error naming the conflicting PID(s) |
| `shutdown_codesys` | If launcher's tracked PID is null (crash recovery, or the orphan was spawned by a previous server process), shutdown returns "nothing to do" — orphan keeps holding the project file lock | Probe `tasklist` and forcibly kill any `CODESYS.exe` matches when shutdown is requested with no tracked PID |

## What's NOT in this PR

This is a fix-only PR. New tools (mirror export, version anchor + release pipeline, CODESYS Git plugin wrappers, online version readback) and all fork-specific docs/branding are kept in the [phobicdotno/Codesys-MCP-SP21-plus](https://github.com/phobicdotno/Codesys-MCP-SP21-plus) fork and not proposed here.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 35/35 pass
- [ ] Reviewer-side: smoke against SP19 (validate no regression on the platform that worked before)
- [ ] Reviewer-side: smoke against SP21 / SP22 (validate the headline fix)

Per-tool verification on SP21/SP22 is documented in the fork's [`docs/SMOKE-TEST-2026-04-25.md`](https://github.com/phobicdotno/Codesys-MCP-SP21-plus/blob/main/docs/SMOKE-TEST-2026-04-25.md) — happy to copy any portion into this PR if useful.